### PR TITLE
Align naming standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ No modules.
 The following resources are used by this module:
 
 - [aws_alb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb) (resource)
-- [aws_kms_key.alb-key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) (resource)
-- [aws_s3_bucket.alb-access-logs-bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) (resource)
-- [aws_s3_bucket_acl.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) (resource)
-- [aws_s3_bucket_public_access_block.public-block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) (resource)
-- [aws_s3_bucket_server_side_encryption_configuration.alb-log-encryption-config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) (resource)
+- [aws_kms_key.alb_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) (resource)
+- [aws_s3_bucket.alb_access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) (resource)
+- [aws_s3_bucket_acl.bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) (resource)
+- [aws_s3_bucket_public_access_block.public_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) (resource)
+- [aws_s3_bucket_server_side_encryption_configuration.alb_log_encryption_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) (resource)
 
 ## Required Inputs
 
@@ -40,12 +40,6 @@ The following input variables are required:
 ### <a name="input_name"></a> [name](#input_name)
 
 Description: The name to give the load balancer. The name will have the namespace appended
-
-Type: `string`
-
-### <a name="input_namespace"></a> [namespace](#input_namespace)
-
-Description: Determines naming convention of assets. Generally follows DNS naming convention.
 
 Type: `string`
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,5 @@
-#PLS READ - NEEDS REFINEMENT AND ABSTRACTING
-
 resource "aws_alb" "alb" {
-  name                       = "${var.name}-${var.namespace}"
+  name                       = var.name
   tags                       = var.tags
   load_balancer_type         = "application"
   security_groups            = var.security_group_ids
@@ -9,24 +7,23 @@ resource "aws_alb" "alb" {
   drop_invalid_header_fields = true
 
   access_logs {
-    bucket  = aws_s3_bucket.alb-access-logs-bucket.bucket
-    prefix  = "${var.name}-${var.namespace}-alb"
+    bucket  = aws_s3_bucket.alb_access_logs.bucket
+    prefix  = "${var.name}-alb"
     enabled = true
   }
 
 }
 
-resource "aws_s3_bucket" "alb-access-logs-bucket" {
-  bucket = "${var.name}-${var.namespace}-alb-access-logs"
+resource "aws_s3_bucket" "alb_access_logs" {
+  bucket = "${var.name}-alb-access-logs"
 
   tags = {
-    Name        = "${var.name}-bucket"
-    Environment = "${var.namespace}"
+    Name = "${var.name}-alb-access-logs-bucket"
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "public-block" {
-  bucket = aws_s3_bucket.alb-access-logs-bucket.id
+resource "aws_s3_bucket_public_access_block" "public_block" {
+  bucket = aws_s3_bucket.alb_access_logs.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -34,25 +31,25 @@ resource "aws_s3_bucket_public_access_block" "public-block" {
   restrict_public_buckets = true
 }
 
-resource "aws_kms_key" "alb-key" {
-  description         = "${var.name}-${var.namespace}-key"
+resource "aws_kms_key" "alb_key" {
+  description         = "${var.name}-alb-key"
   enable_key_rotation = true
 
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "alb-log-encryption-config" {
-  bucket = aws_s3_bucket.alb-access-logs-bucket.bucket
+resource "aws_s3_bucket_server_side_encryption_configuration" "alb_log_encryption_config" {
+  bucket = aws_s3_bucket.alb_access_logs.bucket
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.alb-key.id
+      kms_master_key_id = aws_kms_key.alb_key.id
       sse_algorithm     = "aws:kms"
     }
   }
 }
 
-resource "aws_s3_bucket_acl" "example" {
-  bucket = aws_s3_bucket.alb-access-logs-bucket.id
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  bucket = aws_s3_bucket.alb_access_logs.id
   acl    = "private"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "name" {
   description = "The name to give the load balancer. The name will have the namespace appended"
 }
 
-variable "namespace" {
-  type        = string
-  description = "Determines naming convention of assets. Generally follows DNS naming convention."
-}
-
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the AWS resources."


### PR DESCRIPTION
Pushing this ahead of my actual important changes:

- Removes the `namespace` argument in favor of just passing through `name`
- Aligns resource names with Terraform community conventions (`snake_case` and not restating the type of resource in the name)