### PR TITLE
6 s3bucket transient error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,3 +121,8 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
   bucket = aws_s3_bucket.alb_access_logs.id
   acl    = "private"
 }
+
+resource "aws_s3_bucket_policy" "access_logs" {
+  bucket = aws_s3_bucket.alb_access_logs.id
+  policy = data.aws_iam_policy_document.allow_load_balancer_write.json
+}

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,14 @@ resource "aws_alb" "this" {
 
   access_logs {
     bucket  = aws_s3_bucket.alb_access_logs.bucket
-    prefix  = "${var.name}-alb"
+    prefix  = local.log_prefix
     enabled = true
   }
 
+}
+
+locals {
+  log_prefix = "${var.name}-alb"
 }
 
 resource "aws_lb_listener" "https" {
@@ -83,10 +87,24 @@ resource "aws_s3_bucket_public_access_block" "public_block" {
   restrict_public_buckets = true
 }
 
-resource "aws_kms_key" "alb_key" {
-  description         = "${var.name}-alb-key"
-  enable_key_rotation = true
+data "aws_elb_service_account" "main" {}
+data "aws_caller_identity" "current" {}
 
+data "aws_iam_policy_document" "allow_load_balancer_write" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_elb_service_account.main.arn}"]
+    }
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.alb_access_logs.arn}/${local.log_prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+    ]
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "alb_log_encryption_config" {
@@ -94,8 +112,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "alb_log_encryptio
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.alb_key.id
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "AES256"
     }
   }
 }


### PR DESCRIPTION
#6

This uses the default AWS encryption key rather than a custom KMS key. Per the ALB docs here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html

> The only server-side encryption option that's supported is Amazon S3-managed keys (SSE-S3). For more information, see [Amazon S3-managed encryption keys (SSE-S3)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html).